### PR TITLE
feat: Add module alias configuration for improved import paths

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+// config for alias
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import Board from './pages/Boards/_id'
+import Board from '~/pages/Boards/_id'
 
 function App() {
   return (

--- a/src/components/AppBar/index.jsx
+++ b/src/components/AppBar/index.jsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box'
-import ModeSelect from '../ModeSelect'
+
+import ModeSelect from '~/components/ModeSelect'
 
 function AppBar() {
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,8 +3,8 @@ import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/s
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
-import App from './App.jsx'
-import theme from './theme/theme.js'
+import App from '~/App.jsx'
+import theme from '~/theme/theme.js'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/pages/Boards/_id.jsx
+++ b/src/pages/Boards/_id.jsx
@@ -1,6 +1,7 @@
 // Board details
 import Container from '@mui/material/Container'
-import AppBar from '../../components/AppBar'
+
+import AppBar from '~/components/AppBar'
 import BoardBar from './BoardBar'
 import BoardContent from './BoardContent'
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,12 @@ import react from '@vitejs/plugin-react-swc'
 export default defineConfig({
   plugins: [react()],
   // base: './'
+  resolve: {
+    alias: [
+      {
+        find: '~',
+        replacement: '/src'
+      }
+    ]
+  }
 })


### PR DESCRIPTION
- Create jsconfig.json for JavaScript path aliases
- Update Vite config to support '~' alias for src directory
- Refactor import statements across multiple components to use new '~' alias