### PR TITLE
fix: custom drag-and-drop sensors and integrate into board columns

### DIFF
--- a/src/customHooks/index.js
+++ b/src/customHooks/index.js
@@ -1,0 +1,1 @@
+// customHooks

--- a/src/customLibraries/DndKitSensors.js
+++ b/src/customLibraries/DndKitSensors.js
@@ -1,0 +1,26 @@
+import {
+  MouseSensor as DndKitMouseSensor,
+  TouchSensor as DndKitTouchSensor
+} from '@dnd-kit/core'
+
+// Block DnD event propagation if element have "data-no-dnd" attribute
+const handler = ({ nativeEvent: event }) => {
+  let cur = event.target
+
+  while (cur) {
+    if (cur.dataset && cur.dataset.noDnd) {
+      return false
+    }
+    cur = cur.parentElement
+  }
+
+  return true
+}
+
+export class MouseSensor extends DndKitMouseSensor {
+  static activators = [{ eventName: 'onMouseDown', handler }]
+}
+
+export class TouchSensor extends DndKitTouchSensor {
+  static activators = [{ eventName: 'onTouchStart', handler }]
+}

--- a/src/pages/Boards/BoardContent/BoardContent.jsx
+++ b/src/pages/Boards/BoardContent/BoardContent.jsx
@@ -5,8 +5,6 @@ import ListColumns from './ListColumns/ListColumns'
 import {
   DndContext,
   DragOverlay,
-  MouseSensor,
-  TouchSensor,
   closestCorners,
   defaultDropAnimationSideEffects,
   getFirstCollision,
@@ -21,6 +19,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Column from './ListColumns/Column/Column'
 import Card from './ListColumns/Column/ListCards/Card/Card'
 import { generatePlaceholderCard } from '~/utils/formatters'
+import { MouseSensor, TouchSensor } from '~/customLibraries/DndKitSensors'
 
 const ACTIVE_DRAG_ITEM_TYPE = {
   COLUMN: 'ACTIVE_DRAG_ITEM_TYPE_COLUMN',

--- a/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
@@ -199,6 +199,7 @@ function Column({ column }) {
             </Box>
           ) : (
             <Box
+              data-no-dnd="true"
               sx={{
                 height: '100%',
                 display: 'flex',


### PR DESCRIPTION
This pull request introduces a new custom drag-and-drop sensor implementation and integrates it into the board content component. The most important changes include the addition of custom mouse and touch sensors, the modification of imports to use these sensors, and the addition of a data attribute to prevent drag-and-drop in specific elements.

Custom drag-and-drop sensor implementation:

* [`src/customLibraries/DndKitSensors.js`](diffhunk://#diff-049661f5fdf72b391393fed9794a1e66a60b880628b97ff12bccabbd75a32cf5R1-R26): Added `MouseSensor` and `TouchSensor` classes that extend from `@dnd-kit/core` sensors and include a handler to block drag-and-drop events if an element has the `data-no-dnd` attribute.

Integration of custom sensors:

* [`src/pages/Boards/BoardContent/BoardContent.jsx`](diffhunk://#diff-26220a1cd2947496399023d53aceac7748dc72e2b62ae9c69c370ec2b41f529aR22): Updated imports to use the new `MouseSensor` and `TouchSensor` from `~/customLibraries/DndKitSensors`.
* [`src/pages/Boards/BoardContent/BoardContent.jsx`](diffhunk://#diff-26220a1cd2947496399023d53aceac7748dc72e2b62ae9c69c370ec2b41f529aL8-L9): Removed old sensor imports (`MouseSensor` and `TouchSensor`) from `@dnd-kit/core`.

Preventing drag-and-drop on specific elements:

* [`src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx`](diffhunk://#diff-b90a30928786826cb198dcf1ef422e9d3d90caef9b32cdb41d2004b7c5fe99f8R202): Added the `data-no-dnd="true"` attribute to a `Box` component to prevent drag-and-drop events on that element.

Minor changes:

* [`src/customHooks/index.js`](diffhunk://#diff-5e197887ee67fe13f643193e9382cbf2982102049d71271df05447eba741e540R1): Added a comment to indicate the file contains custom hooks.