### PR TITLE
feat: add toast notifications for empty card and column titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "axios": "^1.5.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-toastify": "^9.1.3"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,8 @@ import CssBaseline from '@mui/material/CssBaseline'
 import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 
 import App from '~/App.jsx'
 import theme from '~/theme/theme.js'
@@ -11,6 +13,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <CssVarsProvider theme={theme}>
       <CssBaseline />
       <App />
+      <ToastContainer position="bottom-left" theme="colored" />
     </CssVarsProvider>
   </React.StrictMode>
 )

--- a/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx
@@ -25,6 +25,7 @@ import TextField from '@mui/material/TextField'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import theme from '~/theme/theme'
+import { toast } from 'react-toastify'
 
 function Column({ column }) {
   const [newCardTitle, setNewCardTitle] = useState('')
@@ -37,6 +38,9 @@ function Column({ column }) {
 
   const addNewCard = () => {
     if (!newCardTitle) {
+      toast.error('Please enter card title', {
+        position: 'bottom-right'
+      })
       return
     }
 
@@ -261,9 +265,7 @@ function Column({ column }) {
                       boxShadow: 'none'
                     }
                   }}
-                  onClick={() => {
-                    // Add card
-                  }}
+                  onClick={addNewCard}
                 >
                   Add
                 </Button>

--- a/src/pages/Boards/BoardContent/ListColumns/ListColumns.jsx
+++ b/src/pages/Boards/BoardContent/ListColumns/ListColumns.jsx
@@ -10,6 +10,7 @@ import {
   horizontalListSortingStrategy
 } from '@dnd-kit/sortable'
 import { useState } from 'react'
+import { toast } from 'react-toastify'
 
 function ListColumns({ columns }) {
   const [newColumnTitle, setNewColumnTitle] = useState('')
@@ -22,6 +23,7 @@ function ListColumns({ columns }) {
 
   const addNewColumn = () => {
     if (!newColumnTitle) {
+      toast.error('Please enter column title')
       return
     }
 
@@ -133,9 +135,7 @@ function ListColumns({ columns }) {
                     boxShadow: 'none'
                   }
                 }}
-                onClick={() => {
-                  // Add new column
-                }}
+                onClick={addNewColumn}
               >
                 Add Column
               </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,6 +972,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 clsx@^2.1.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
@@ -2224,6 +2229,13 @@ react-is@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.0.0.tgz#d6669fd389ff022a9684f708cf6fa4962d1fea7a"
   integrity sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==
+
+react-toastify@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
+  integrity sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
This pull request introduces the `react-toastify` library to provide toast notifications for user feedback in the application. The most important changes include updates to dependencies, integration of `react-toastify` in the main application file, and usage of toast notifications in specific components.

### Dependency Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R29): Added `react-toastify` version `^9.1.3` to dependencies.

### Integration of `react-toastify`:
* [`src/main.jsx`](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edR5-R6): Imported `ToastContainer` from `react-toastify` and included it in the render method to display toast notifications. [[1]](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edR5-R6) [[2]](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edR16)

### Usage of `react-toastify` in Components:
* [`src/pages/Boards/BoardContent/ListColumns/Column/Column.jsx`](diffhunk://#diff-b90a30928786826cb198dcf1ef422e9d3d90caef9b32cdb41d2004b7c5fe99f8R28): Imported `toast` from `react-toastify` and added a toast notification for empty card title input in the `addNewCard` function. Also updated the `onClick` handler to use `addNewCard`. [[1]](diffhunk://#diff-b90a30928786826cb198dcf1ef422e9d3d90caef9b32cdb41d2004b7c5fe99f8R28) [[2]](diffhunk://#diff-b90a30928786826cb198dcf1ef422e9d3d90caef9b32cdb41d2004b7c5fe99f8R41-R43) [[3]](diffhunk://#diff-b90a30928786826cb198dcf1ef422e9d3d90caef9b32cdb41d2004b7c5fe99f8L264-R268)
* [`src/pages/Boards/BoardContent/ListColumns/ListColumns.jsx`](diffhunk://#diff-5455a95be256eb9997238c39bbad4550d2a1f19ed830d6424e773e03cf5080a5R13): Imported `toast` from `react-toastify` and added a toast notification for empty column title input in the `addNewColumn` function. Also updated the `onClick` handler to use `addNewColumn`. [[1]](diffhunk://#diff-5455a95be256eb9997238c39bbad4550d2a1f19ed830d6424e773e03cf5080a5R13) [[2]](diffhunk://#diff-5455a95be256eb9997238c39bbad4550d2a1f19ed830d6424e773e03cf5080a5R26) [[3]](diffhunk://#diff-5455a95be256eb9997238c39bbad4550d2a1f19ed830d6424e773e03cf5080a5L136-R138)